### PR TITLE
[WIP] [CAN BE SIMPLIFIED A LITTLE BIT] PVPN: Add boolean parameter 'routes_depend_on_peer' and apply relevant changes (#12173)

### DIFF
--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -1,18 +1,19 @@
 #
 define wireguard::peer (
-  Array[String]    $allowedips,
-  String           $iface               = $title,
+ Array[String]     $allowedips,
+  String            $iface                 = $title,
   Optional[
     Pattern[/[A-Za-z0-9+\/=]{44}/]
-  ]                $publickey           = $facts['wireguard'] ? {
+  ]                 $publickey             = $facts['wireguard'] ? {
     undef   => undef,
     default => $facts['wireguard'][$iface],
   },
-  Optional[String] $presharedkey        = undef,
-  Optional[String] $endpoint            = undef,
-  Integer[0,65535] $persistentkeepalive = 0, # 0 == off
-  Array[String]    $export_tags         = [],
-  String           $peername            = $::fqdn,
+  Optional[String]  $presharedkey          = undef,
+  Optional[String]  $endpoint              = undef,
+  Integer[0,65535]  $persistentkeepalive   = 0, # 0 == off
+  Array[String]     $export_tags           = [],
+  String            $peername              = $::fqdn,
+  Optional[Boolean] $routes_depend_on_peer = true,
 ) {
   # the publickey is not optional despite the parameter specification
   # saying otherwise but we don't want to fail a run if it's not there
@@ -54,28 +55,61 @@ define wireguard::peer (
       tag     => $export_tags,
     }
 
-    # routes are only meaningful if there are multiple allowedips (Destination=)
-    if length($allowedips) > 1 {
-      # [Route]
-      $route = inline_epp(@(EOT), $template_params)
+   if $routes_depend_on_peer {
+      # routes are only meaningful if there are multiple allowedips (Destination=)
+      if length($allowedips) > 1 {
+        # [Route]
+        $route = inline_epp(@(EOT), $template_params)
 
-      [Route]
-      <% if length($peername) > 0 { -%>
-      # peer: <%= $peername %>
-      <% } -%>
-      Gateway=<%= $allowedips[0] %>
-      <% $allowedips.each |Integer $index, String $ip| {
-           # skip self (first allowedips)
-           if $index == 0 { next() } -%>
-      Destination=<%= $ip %>
-      <% } -%>
-      | EOT
+        <% if length($peername) > 0 { -%>
+        # peer: <%= $peername %>
+        <% } -%>
+        <% $allowedips.each |Integer $index, String $ip| {
+             # skip self (first allowedips)
+             if $index == 0 { next() } -%>
+        [Route]
+        Gateway=<%= $allowedips[0] %>
+        Destination=<%= $ip %>
+        <%   unless $index == $allowedips.length - 1 { -%>
 
-      @@concat::fragment{ "[Route]-${::fqdn}-${iface}":
-        order   => '10',
-        content => $route,
-        target  => "${iface}.network",
-        tag     => $export_tags,
+        <%   } -%>
+        <% } -%>
+        | EOT
+
+        @@concat::fragment{ "[Route]-${::fqdn}-${iface}":
+          order   => '10',
+          content => $route,
+          target  => "${iface}.network",
+          tag     => $export_tags,
+        }
+      }
+    } else {
+      # routes are only meaningful if there are multiple allowedips (Destination=)
+      if length($allowedips) > 1 {
+        # [Route]
+        $route = inline_epp(@(EOT), $template_params)
+
+        <% if length($peername) > 0 { -%>
+        # peer: <%= $peername %>
+        <% } -%>
+        <% $allowedips.each |Integer $index, String $ip| {
+             # skip self (first allowedips)
+             if $index == 0 { next() } -%>
+        [Route]
+        Destination=<%= $ip %>
+        Scope=link
+        <%   unless $index == $allowedips.length - 1 { -%>
+
+        <%   } -%>
+        <% } -%>
+        | EOT
+
+        @@concat::fragment{ "[Route]-${::fqdn}-${iface}":
+          order   => '10',
+          content => $route,
+          target  => "${iface}.network",
+          tag     => $export_tags,
+        }
       }
     }
   } else {

--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -1,6 +1,6 @@
 #
 define wireguard::peer (
- Array[String]     $allowedips,
+  Array[String]     $allowedips,
   String            $iface                 = $title,
   Optional[
     Pattern[/[A-Za-z0-9+\/=]{44}/]
@@ -55,7 +55,7 @@ define wireguard::peer (
       tag     => $export_tags,
     }
 
-   if $routes_depend_on_peer {
+    if $routes_depend_on_peer {
       # routes are only meaningful if there are multiple allowedips (Destination=)
       if length($allowedips) > 1 {
         # [Route]


### PR DESCRIPTION
* PVPN: Fix indentation in Puppet resource 'wireguard::peer' (#12660)
* PVPN: Add boolean parameter 'routes_depend_on_peer' and apply relevant changes (#12173)
    
    • Fix: when the parameter is set to true, do not only define
      several 'Destination' but also several '[Route]' sections.
    • New feature: when the parameter is set to false, change the
      'Scope' of the routes to 'link'.