### PR TITLE
DIO: Stop notifying class 'systemd::systemctl::daemon_reload' of module 'systemd', when relevant (#13542)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,9 +9,18 @@ class wireguard (
 
   # apply systemd::network changes even if $systemd::manage_networkd is false
   if $restart_networkd and ! $systemd::manage_networkd {
+    $systemd_module_name = load_module_metadata('systemd')['name']
+
     service { 'systemd-networkd': }
-    Systemd::Network <| |>
-    ~> Class['systemd::systemctl::daemon_reload']
-    ~> Service['systemd-networkd']
+    if $systemd_module_name == 'camptocamp-systemd' {
+      Systemd::Network <| |>
+      ~> Class['systemd::systemctl::daemon_reload']
+      ~> Service['systemd-networkd']
+    } elsif $systemd_module_name == 'puppet-systemd' {
+      Systemd::Network <| |>
+      ~> Service['systemd-networkd']
+    } else {
+      fail("Unknown systemd module name '${systemd_module_name}'.")
+    }
   }
 }


### PR DESCRIPTION
DIO: Stop notifying class 'systemd::systemctl::daemon_reload' of module 'systemd', when relevant (#13542)

Do so, in particular, to support the migration from the deprecated
module 'camptocamp/systemd' to the maintained module 'puppet/systemd'.

References:
 • https://github.com/voxpupuli/puppet-systemd/pull/171
 • https://github.com/voxpupuli/puppet-systemd/blob/master/README.md#daemon-reloads