### PR TITLE
Infra: Add 'wireguard::simple_iface' resource (#15847)

### DIFF
--- a/manifests/simple_iface.pp
+++ b/manifests/simple_iface.pp
@@ -1,0 +1,22 @@
+define wireguard::simple_iface (
+  Optional[String] $interface_name = $name,
+  Optional[String] $source         = undef,
+  Optional[String] $content        = undef,
+) {
+  include wireguard
+
+  $service_name="wg-quick@${interface_name}.service"
+
+  file { "/etc/wireguard/${interface_name}.conf":
+    content   => $content,
+    source    => $source,
+    mode      => '0400',
+    show_diff => false,
+    notify    => Service[$service_name],
+  }
+
+  service { $service_name:
+    ensure => running,
+    enable => true,
+  }
+}


### PR DESCRIPTION
A resource to create a wireguard interface from a config file.

The resource will create a config file with proper permissions and restart the wireguard service on config change 